### PR TITLE
Fixed wrong dependency name in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -36,7 +36,7 @@
   <!-- CUSTOM -->
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning_interface</depend>
-  <depend>moveit_perception</depend>
+  <depend>moveit_ros_perception</depend>
   <depend>moveit_visual_tools</depend>
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
Shouldn't the ROS package be `moveit_ros_perception` instead of `moveit_perception` (see [moveit_ros_perception](https://wiki.ros.org/moveit_ros_perception)? I got an error while building. Could also be caused by my setup. I'm working on ROS kinetic.