### PR TITLE
[WIP] rename the arm controller name to panda_moveit_config original one

### DIFF
--- a/config/panda_control.yaml
+++ b/config/panda_control.yaml
@@ -3,7 +3,7 @@
         type: joint_state_controller/JointStateController
         publish_rate: 100
 
-    panda_arm_controller:
+    position_joint_trajectory_controller:
         type: position_controllers/JointTrajectoryController
         joints:
             - panda_joint1

--- a/launch/simulation.launch
+++ b/launch/simulation.launch
@@ -26,7 +26,7 @@
 
 
     <!-- load the controllers -->
-    <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="joint_state_controller panda_arm_controller" />
+    <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="joint_state_controller position_joint_trajectory_controller" />
     <node if="$(arg load_gripper)" name="controller_spawner_hand" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="panda_hand_controller" />
 
 

--- a/src/robot_state_initializer.cpp
+++ b/src/robot_state_initializer.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
   ros::Duration(2.0).sleep();
 
   // 1. switch from default joint trajectory controller to custom position controller
-  std::string panda_arm_controller{"panda_arm_controller"}, panda_hand_controller{"panda_hand_controller"},
+  std::string panda_arm_controller{"position_joint_trajectory_controller"}, panda_hand_controller{"franka_gripper"},
       joint_position_controller{"joint_position_controller"};
   std::vector<std::string> stop_controllers{panda_arm_controller, panda_hand_controller};
   std::vector<std::string> start_controllers{joint_position_controller};


### PR DESCRIPTION
You should revert the name of the arm controller to the original one in `panda_moveit_config`.

This PR is WIP because we also have to revert some of these changes.
https://github.com/erdalpekel/panda_moveit_config/commit/a8087abb35a680f95e5fdf501f27de68aadb1337

I want your opinion to revert the name.